### PR TITLE
fix SEAMSECURITY-44 by renaming the identity bean from the example to opI

### DIFF
--- a/examples/openid-op/src/main/java/org/jboss/seam/security/examples/openid/Login.java
+++ b/examples/openid-op/src/main/java/org/jboss/seam/security/examples/openid/Login.java
@@ -23,7 +23,7 @@ public class Login {
     private DialogueManager dialogueManager;
 
     @Inject
-    private Identity identity;
+    private OpIdentity identity;
 
     public String getUserName() {
         return userName;

--- a/examples/openid-op/src/main/java/org/jboss/seam/security/examples/openid/OpIdentity.java
+++ b/examples/openid-op/src/main/java/org/jboss/seam/security/examples/openid/OpIdentity.java
@@ -12,7 +12,7 @@ import org.jboss.seam.security.external.openid.api.OpenIdProviderApi;
 
 @SessionScoped
 @Named
-public class Identity implements Serializable {
+public class OpIdentity implements Serializable {
     private static final long serialVersionUID = -7096110154986991513L;
 
     private String userName;

--- a/examples/openid-op/src/main/java/org/jboss/seam/security/examples/openid/OpenIdProviderSpiImpl.java
+++ b/examples/openid-op/src/main/java/org/jboss/seam/security/examples/openid/OpenIdProviderSpiImpl.java
@@ -17,7 +17,7 @@ public class OpenIdProviderSpiImpl implements OpenIdProviderSpi {
     private ServletContext servletContext;
 
     @Inject
-    private Identity identity;
+    private OpIdentity identity;
 
     @Inject
     private OpenIdProviderApi opApi;

--- a/examples/openid-op/src/main/webapp/Attributes.xhtml
+++ b/examples/openid-op/src/main/webapp/Attributes.xhtml
@@ -5,7 +5,7 @@
         xmlns:f="http://java.sun.com/jsf/core">
     <f:metadata>
         <f:event type="preRenderView"
-                 listener="#{identity.redirectToLoginIfNotLoggedIn}"/>
+                 listener="#{opIdentity.redirectToLoginIfNotLoggedIn}"/>
     </f:metadata>
     <ui:composition template="/PageTemplate.xhtml">
 

--- a/examples/openid-op/src/main/webapp/Menu.xhtml
+++ b/examples/openid-op/src/main/webapp/Menu.xhtml
@@ -6,12 +6,12 @@
 
     <h:form>
         <h:commandLink value="Login" action="/Login.xhtml"
-                       disabled="#{identity.loggedIn}"/> |
+                       disabled="#{opIdentity.loggedIn}"/> |
         <h:commandLink value="Configuration" action="/Configuration.xhtml"/> |
         <h:commandLink value="Session Management"
-                       action="/SessionManagement.xhtml" disabled="#{!identity.loggedIn}"/> |
-        <h:commandLink value="Logout" action="#{identity.logout}"
-                       disabled="#{!identity.loggedIn}"/>
+                       action="/SessionManagement.xhtml" disabled="#{!opIdentity.loggedIn}"/> |
+        <h:commandLink value="Logout" action="#{opIdentity.logout}"
+                       disabled="#{!opIdentity.loggedIn}"/>
     </h:form>
 
 </ui:composition>

--- a/examples/openid-op/src/main/webapp/SessionManagement.xhtml
+++ b/examples/openid-op/src/main/webapp/SessionManagement.xhtml
@@ -5,7 +5,7 @@
         xmlns:f="http://java.sun.com/jsf/core">
     <f:metadata>
         <f:event type="preRenderView"
-                 listener="#{identity.redirectToLoginIfNotLoggedIn}"/>
+                 listener="#{opIdentity.redirectToLoginIfNotLoggedIn}"/>
     </f:metadata>
     <ui:composition template="/PageTemplate.xhtml">
 
@@ -15,9 +15,9 @@
 
         <h:panelGrid columns="2" columnClasses="propertyName, propertyValue">
             <h:outputText value="User name"/>
-            <h:outputText value="#{identity.userName}"/>
+            <h:outputText value="#{opIdentity.userName}"/>
             <h:outputText value="User's OpenID"/>
-            <h:outputText value="#{identity.opLocalIdentifier}"/>
+            <h:outputText value="#{opIdentity.opLocalIdentifier}"/>
         </h:panelGrid>
 
     </ui:composition>

--- a/examples/openid-op/src/main/webapp/UserInfo.xhtml
+++ b/examples/openid-op/src/main/webapp/UserInfo.xhtml
@@ -5,7 +5,7 @@
         xmlns:f="http://java.sun.com/jsf/core">
     <f:metadata>
         <f:event type="preRenderView"
-                 listener="#{identity.redirectToLoginIfNotLoggedIn}"/>
+                 listener="#{opIdentity.redirectToLoginIfNotLoggedIn}"/>
     </f:metadata>
     <ui:composition template="/PageTemplate.xhtml">
 
@@ -13,11 +13,11 @@
 
         <h:panelGrid columns="2" columnClasses="propertyName, propertyValue">
             <h:outputText value="Verified User Identifier"/>
-            <h:outputText value="#{identity.openIdPrincipal.identifier}"/>
+            <h:outputText value="#{opIdentity.openIdPrincipal.identifier}"/>
             <h:outputText value="OpenID Provider"/>
-            <h:outputText value="#{identity.openIdPrincipal.openIdProvider}"/>
+            <h:outputText value="#{opIdentity.openIdPrincipal.openIdProvider}"/>
             <h:outputText value="Email"/>
-            <h:outputText value="#{identity.openIdPrincipal.attributes.email}"/>
+            <h:outputText value="#{opIdentity.openIdPrincipal.attributes.email}"/>
         </h:panelGrid>
 
     </ui:composition>


### PR DESCRIPTION
fix SEAMSECURITY-44 by renaming the identity bean from the example to opIdentity to avoid conflict with identity bean from security API
