### PR TITLE
NullPointer OpenIdPrincipalImpl.getAtribute()

### DIFF
--- a/external/src/main/java/org/jboss/seam/security/external/OpenIdPrincipalImpl.java
+++ b/external/src/main/java/org/jboss/seam/security/external/OpenIdPrincipalImpl.java
@@ -39,7 +39,7 @@ public class OpenIdPrincipalImpl implements OpenIdPrincipal {
         if (attributeValues == null) return null;
 
         List<String> values = attributeValues.get(alias);
-        if (values.size() == 0) {
+        if (values!=null&&values.size() == 0) {
             return null;
         } else if (values.size() == 1) {
             return (String) attributeValues.get(alias).get(0);


### PR DESCRIPTION
NullPointer in org.jboss.seam.security.external.OpenIdPrincipalImpl.getAttribute(OpenIdPrincipalImpl.java:48) when there is no valu in map at all.
