### PR TITLE
Use WEB-INF/security.drl if security.drl not found on classpath

### DIFF
--- a/impl/src/main/java/org/jboss/seam/security/permission/SecurityRuleProducer.java
+++ b/impl/src/main/java/org/jboss/seam/security/permission/SecurityRuleProducer.java
@@ -32,6 +32,10 @@ public class SecurityRuleProducer {
     @Resource("security.drl")
     InputStream securityRules;
 
+    @Inject
+    @Resource("WEB-INF/security.drl")
+    InputStream webInfSecurityRules;
+
     @Produces
     @ApplicationScoped
     @Security
@@ -41,7 +45,9 @@ public class SecurityRuleProducer {
 
         KnowledgeBuilder kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder(config);
 
-        org.drools.io.Resource resource = ResourceFactory.newInputStreamResource(securityRules);
+        org.drools.io.Resource resource = ResourceFactory.newInputStreamResource(
+            securityRules != null ? securityRules : webInfSecurityRules);
+
         kbuilder.add(resource, ResourceType.DRL);
 
         KnowledgeBuilderErrors kbuildererrors = kbuilder.getErrors();


### PR DESCRIPTION
Fixes the security.drl problem on Glassfish and AS7 (SEAMSECURITY-81)
