### PR TITLE
SEAMSECURITY-76 

### DIFF
--- a/examples/openid-op/pom.xml
+++ b/examples/openid-op/pom.xml
@@ -12,7 +12,7 @@
    <parent>
       <groupId>org.jboss.seam.security</groupId>
       <artifactId>seam-security-parent</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 
@@ -37,6 +37,16 @@
       <dependency>
          <groupId>org.jboss.seam.servlet</groupId>
          <artifactId>seam-servlet</artifactId>
+      </dependency>
+
+      <dependency>
+          <groupId>org.jboss.seam.config</groupId>
+          <artifactId>seam-config-xml</artifactId>
+      </dependency>
+
+      <dependency>
+          <groupId>joda-time</groupId>
+          <artifactId>joda-time</artifactId>
       </dependency>
 
       <dependency>

--- a/examples/openid-op/src/main/resources/META-INF/seam-beans.xml
+++ b/examples/openid-op/src/main/resources/META-INF/seam-beans.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:s="urn:java:ee"
+       xmlns:openid="urn:java:org.jboss.seam.security.external.openid"
+       xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee http://jboss.org/schema/cdi/beans_1_0.xsd">
+
+    <openid:OpenIdProviderInApplicationScopeProducer>
+        <s:modifies/>
+    </openid:OpenIdProviderInApplicationScopeProducer>
+
+</beans>

--- a/examples/openid-op/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/openid-op/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+    <!--
     <alternatives>
         <class>org.jboss.seam.security.external.openid.OpenIdProviderInApplicationScopeProducer</class>
     </alternatives>
+    -->
 </beans>

--- a/examples/openid-rp/pom.xml
+++ b/examples/openid-rp/pom.xml
@@ -9,7 +9,7 @@
    <parent>
       <groupId>org.jboss.seam.security</groupId>
       <artifactId>seam-security-parent</artifactId>
-      <version>3.0.1-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/examples/openid-rp/src/main/java/org/jboss/seam/security/examples/id_consumer/OpenIdRelyingPartyCustomizer.java
+++ b/examples/openid-rp/src/main/java/org/jboss/seam/security/examples/id_consumer/OpenIdRelyingPartyCustomizer.java
@@ -1,0 +1,28 @@
+package org.jboss.seam.security.examples.openid;
+
+import java.util.Properties;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
+
+import org.jboss.seam.security.external.openid.api.OpenIdRelyingPartyConfigurationApi;
+import org.jboss.seam.servlet.event.Initialized;
+import org.jboss.seam.solder.resourceLoader.Resource;
+
+
+public class OpenIdRelyingPartyCustomizer {
+    @Inject
+    @Resource("openIdRelayingParty.properties")
+    private Properties properties;
+
+    public void servletInitialized(@Observes @Initialized final ServletContext context, OpenIdRelyingPartyConfigurationApi op) {
+
+        PropertyReader propertyReader = new PropertyReader(properties);
+
+        op.setHostName(propertyReader.getString("hostName", "www.openid-rp.com"));
+        op.setPort(propertyReader.getInt("port", 8080));
+        op.setProtocol(propertyReader.getString("protocol", "http"));
+    }
+
+}

--- a/examples/openid-rp/src/main/java/org/jboss/seam/security/examples/id_consumer/OpenIdRelyingPartySpiImpl.java
+++ b/examples/openid-rp/src/main/java/org/jboss/seam/security/examples/id_consumer/OpenIdRelyingPartySpiImpl.java
@@ -31,7 +31,7 @@ public class OpenIdRelyingPartySpiImpl implements OpenIdRelyingPartySpi {
     public void loginSucceeded(OpenIdPrincipal principal, ResponseHolder responseHolder) {
         try {
             openIdAuthenticator.success(principal);
-            deferredAuthentication.fire(new DeferredAuthenticationEvent());
+            deferredAuthentication.fire(new DeferredAuthenticationEvent(true));
 
             responseHolder.getResponse().sendRedirect(servletContext.getContextPath() + "/UserInfo.jsf");
         } catch (IOException e) {

--- a/examples/openid-rp/src/main/java/org/jboss/seam/security/examples/id_consumer/PropertyReader.java
+++ b/examples/openid-rp/src/main/java/org/jboss/seam/security/examples/id_consumer/PropertyReader.java
@@ -1,0 +1,44 @@
+package org.jboss.seam.security.examples.openid;
+
+import java.util.Properties;
+
+import org.jboss.seam.solder.core.Veto;
+
+
+@Veto
+public class PropertyReader {
+    private Properties properties;
+
+    public PropertyReader(Properties properties) {
+        super();
+        this.properties = properties;
+    }
+
+    public String getString(String name, String defaultValue) {
+        if (properties != null) {
+            return properties.getProperty(name, defaultValue);
+        }
+        return defaultValue;
+    }
+
+    public int getInt(String name, int defaultValue) {
+        if (properties != null && properties.containsKey(name)) {
+            return Integer.parseInt(properties.getProperty(name));
+        }
+        return defaultValue;
+    }
+
+    public boolean getBoolean(String name, boolean defaultValue) {
+        if (properties != null && properties.containsKey(name)) {
+            return Boolean.parseBoolean(properties.getProperty(name));
+        }
+        return defaultValue;
+    }
+
+    public String[] getStringArray(String name, String[] defaultValue) {
+        if (properties != null && properties.containsKey(name)) {
+            return properties.getProperty(name).split(";");
+        }
+        return defaultValue;
+    }
+}

--- a/examples/openid-rp/src/main/resources/META-INF/seam-beans.xml
+++ b/examples/openid-rp/src/main/resources/META-INF/seam-beans.xml
@@ -7,12 +7,20 @@
        xsi:schemaLocation="
       http://java.sun.com/xml/ns/javaee http://jboss.org/schema/cdi/beans_1_0.xsd">
 
+    
+    <!-- This doesn't seem to work -->
+    <!--
     <openid:OpenIdRpBean>
         <s:modifies/>
         <openid:hostName>www.openid-rp.com</openid:hostName>
         <openid:port>8080</openid:port>
         <openid:protocol>http</openid:protocol>
     </openid:OpenIdRpBean>
+    -->
+
+    <openid:OpenIdRpInApplicationScopeProducer>
+        <s:modifies/>
+    </openid:OpenIdRpInApplicationScopeProducer>
 
     <security:IdentityImpl>
         <s:modifies/>

--- a/examples/saml-idp/pom.xml
+++ b/examples/saml-idp/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.seam.security</groupId>
 		<artifactId>seam-security-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -35,11 +35,20 @@
 			</exclusions>
 		</dependency>
 
-      <dependency>
-         <groupId>org.jboss.seam.servlet</groupId>
-         <artifactId>seam-servlet</artifactId>
-         <version>3.0.0.Alpha3</version>
-      </dependency>
+        <dependency>
+            <groupId>org.jboss.seam.servlet</groupId>
+            <artifactId>seam-servlet</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.seam.config</groupId>
+            <artifactId>seam-config-xml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
 
 		<dependency>
 			<groupId>javax.enterprise</groupId>

--- a/examples/saml-idp/src/main/java/org/jboss/seam/security/examples/id_provider/Login.java
+++ b/examples/saml-idp/src/main/java/org/jboss/seam/security/examples/id_provider/Login.java
@@ -21,7 +21,7 @@ public class Login {
     private DialogueManager dialogueManager;
 
     @Inject
-    private Identity identity;
+    private SamlIdentity identity;
 
     public String getUserName() {
         return userName;

--- a/examples/saml-idp/src/main/java/org/jboss/seam/security/examples/id_provider/SamlIdentity.java
+++ b/examples/saml-idp/src/main/java/org/jboss/seam/security/examples/id_provider/SamlIdentity.java
@@ -11,7 +11,7 @@ import org.jboss.seam.security.external.saml.api.SamlIdentityProviderApi;
 import org.jboss.seam.security.external.saml.api.SamlIdpSession;
 
 @Named
-public class Identity implements Serializable {
+public class SamlIdentity implements Serializable {
     private static final long serialVersionUID = 3739296115750412807L;
 
     @Inject

--- a/examples/saml-idp/src/main/java/org/jboss/seam/security/examples/id_provider/SamlIdentityProviderSpiImpl.java
+++ b/examples/saml-idp/src/main/java/org/jboss/seam/security/examples/id_provider/SamlIdentityProviderSpiImpl.java
@@ -19,7 +19,7 @@ public class SamlIdentityProviderSpiImpl implements SamlIdentityProviderSpi {
     private ServletContext servletContext;
 
     @Inject
-    private Identity identity;
+    private SamlIdentity identity;
 
     @Inject
     private SamlIdentityProviderApi idpApi;

--- a/examples/saml-idp/src/main/resources/META-INF/seam-beans.xml
+++ b/examples/saml-idp/src/main/resources/META-INF/seam-beans.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"
+       xmlns:s="urn:java:ee"
+       xmlns:idp="urn:java:org.jboss.seam.security.external.saml.idp">
+  
+    <idp:SamlIdpInApplicationScopeProducer>
+        <s:modifies/>
+    </idp:SamlIdpInApplicationScopeProducer>
+</beans>

--- a/examples/saml-idp/src/main/webapp/Menu.xhtml
+++ b/examples/saml-idp/src/main/webapp/Menu.xhtml
@@ -6,14 +6,14 @@
 
     <h:form>
         <h:commandLink value="Login" action="/Login.xhtml"
-                       disabled="#{identity.loggedIn}"/> |
+                       disabled="#{samlIdentity.loggedIn}"/> |
         <h:commandLink value="Configuration" action="/Configuration.xhtml"/> |
         <h:commandLink value="Session Management" action="/SessionManagement.xhtml"
-                       disabled="#{!identity.loggedIn}"/> |
-        <h:commandLink value="Local Logout" action="#{identity.localLogout}"
-                       disabled="#{!identity.loggedIn}"/> |
-        <h:commandLink value="Global Logout" action="#{identity.globalLogout}"
-                       disabled="#{!identity.loggedIn or identity.samlIdpSession == null}"/>
+                       disabled="#{!samlIdentity.loggedIn}"/> |
+        <h:commandLink value="Local Logout" action="#{samlIdentity.localLogout}"
+                       disabled="#{!samlIdentity.loggedIn}"/> |
+        <h:commandLink value="Global Logout" action="#{samlIdentity.globalLogout}"
+                       disabled="#{!samlIdentity.loggedIn or samlIdentity.samlIdpSession == null}"/>
     </h:form>
 
 </ui:composition>

--- a/examples/saml-idp/src/main/webapp/SessionManagement.xhtml
+++ b/examples/saml-idp/src/main/webapp/SessionManagement.xhtml
@@ -5,7 +5,7 @@
         xmlns:f="http://java.sun.com/jsf/core">
     <f:metadata>
         <f:event type="preRenderView"
-                 listener="#{identity.redirectToLoginIfNotLoggedIn}"/>
+                 listener="#{samlIdentity.redirectToLoginIfNotLoggedIn}"/>
     </f:metadata>
     <ui:composition template="/PageTemplate.xhtml">
 
@@ -14,7 +14,7 @@
         <h2>Logged in user</h2>
 
         <h:outputText
-                value="#{identity.samlIdpSession.principal.nameId.value}"/>
+                value="#{samlIdentity.samlIdpSession.principal.nameId.value}"/>
 
         <h2>Session participants</h2>
 
@@ -36,7 +36,7 @@
                     <h:outputText value="#{sp}"/>
                 </h:column>
                 <h:column>
-                    <h:commandLink action="#{identity.remoteLogin(sp)}" value="Login" target="_blank"/>
+                    <h:commandLink action="#{samlIdentity.remoteLogin(sp)}" value="Login" target="_blank"/>
                 </h:column>
             </h:dataTable>
         </h:form>

--- a/examples/saml-idp/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/saml-idp/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    <!--
     <alternatives>
         <class>org.jboss.seam.security.external.saml.idp.SamlIdpInApplicationScopeProducer</class>
     </alternatives>
+    -->
 </beans>

--- a/examples/saml-sp/pom.xml
+++ b/examples/saml-sp/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.seam.security</groupId>
 		<artifactId>seam-security-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.1.0-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -38,8 +38,17 @@
 		<dependency>
 			<groupId>org.jboss.seam.servlet</groupId>
 			<artifactId>seam-servlet</artifactId>
-			<version>3.0.0.Alpha3</version>
 		</dependency>
+
+        <dependency>
+            <groupId>org.jboss.seam.config</groupId>
+            <artifactId>seam-config-xml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency> 
 
 		<dependency>
 			<groupId>javax.enterprise</groupId>

--- a/examples/saml-sp/src/main/java/org/jboss/seam/security/examples/id_consumer/SamlIdentity.java
+++ b/examples/saml-sp/src/main/java/org/jboss/seam/security/examples/id_consumer/SamlIdentity.java
@@ -11,7 +11,7 @@ import org.jboss.seam.security.external.saml.api.SamlServiceProviderApi;
 import org.jboss.seam.security.external.saml.api.SamlSpSession;
 
 @Model
-public class Identity {
+public class SamlIdentity {
     @Inject
     private SamlServiceProviderApi samlSpApi;
 

--- a/examples/saml-sp/src/main/resources/META-INF/seam-beans.xml
+++ b/examples/saml-sp/src/main/resources/META-INF/seam-beans.xml
@@ -1,0 +1,10 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"
+       xmlns:s="urn:java:ee"
+       xmlns:sp="urn:java:org.jboss.seam.security.external.saml.sp">
+       
+    <sp:SamlSpInVirtualApplicationScopeProducer>
+        <s:modifies/>
+    </sp:SamlSpInVirtualApplicationScopeProducer>
+</beans>
+

--- a/examples/saml-sp/src/main/webapp/Login.xhtml
+++ b/examples/saml-sp/src/main/webapp/Login.xhtml
@@ -12,7 +12,7 @@
                     <h:outputText value="#{idpEntityId}"/>
                 </h:column>
                 <h:column>
-                    <h:commandLink action="#{identity.login(idpEntityId)}"
+                    <h:commandLink action="#{samlIdentity.login(idpEntityId)}"
                                    value="Login"/>
                 </h:column>
             </h:dataTable>

--- a/examples/saml-sp/src/main/webapp/Menu.xhtml
+++ b/examples/saml-sp/src/main/webapp/Menu.xhtml
@@ -6,14 +6,14 @@
 
     <h:form>
         <h:commandLink value="Login" action="/Login.xhtml"
-                       disabled="#{identity.loggedIn}"/> |
+                       disabled="#{samlIdentity.loggedIn}"/> |
         <h:commandLink value="Configuration" action="/Configuration.xhtml"/> |
         <h:commandLink value="User Info" action="/UserInfo.xhtml"
-                       disabled="#{!identity.loggedIn}"/> |
-        <h:commandLink value="Local Logout" action="#{identity.localLogout}"
-                       disabled="#{!identity.loggedIn}"/> |
-        <h:commandLink value="Global Logout" action="#{identity.globalLogout}"
-                       disabled="#{!identity.loggedIn}"/>
+                       disabled="#{!samlIdentity.loggedIn}"/> |
+        <h:commandLink value="Local Logout" action="#{samlIdentity.localLogout}"
+                       disabled="#{!samlIdentity.loggedIn}"/> |
+        <h:commandLink value="Global Logout" action="#{samlIdentity.globalLogout}"
+                       disabled="#{!samlIdentity.loggedIn}"/>
     </h:form>
 
 </ui:composition>

--- a/examples/saml-sp/src/main/webapp/UserInfo.xhtml
+++ b/examples/saml-sp/src/main/webapp/UserInfo.xhtml
@@ -5,7 +5,7 @@
         xmlns:f="http://java.sun.com/jsf/core">
     <f:metadata>
         <f:event type="preRenderView"
-                 listener="#{identity.redirectToLoginIfNotLoggedIn}"/>
+                 listener="#{samlIdentity.redirectToLoginIfNotLoggedIn}"/>
     </f:metadata>
     <ui:composition template="/PageTemplate.xhtml">
 
@@ -14,15 +14,15 @@
         <h:panelGrid columns="2" columnClasses="propertyName, propertyValue">
             <h:outputText value="NameID"/>
             <h:outputText
-                    value="#{identity.samlSpSession.principal.nameId.value}"/>
+                    value="#{samlIdentity.samlSpSession.principal.nameId.value}"/>
             <h:outputText value="NameID format"/>
             <h:outputText
-                    value="#{identity.samlSpSession.principal.nameId.format}"/>
+                    value="#{samlIdentity.samlSpSession.principal.nameId.format}"/>
             <h:outputText value="Identity provider"/>
             <h:outputText
-                    value="#{identity.samlSpSession.identityProvider.entityId}"/>
+                    value="#{samlIdentity.samlSpSession.identityProvider.entityId}"/>
             <h:outputText value="Attributes"/>
-            <h:dataTable value="#{identity.samlSpSession.principal.attributes}"
+            <h:dataTable value="#{samlIdentity.samlSpSession.principal.attributes}"
                          var="attribute">
                 <h:column>
                     <f:facet name="header">Name</f:facet>

--- a/examples/saml-sp/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/saml-sp/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+
+<!--
     <alternatives>
         <class>org.jboss.seam.security.external.saml.sp.SamlSpInVirtualApplicationScopeProducer</class>
     </alternatives>
+-->
 </beans>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -83,6 +83,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.jboss.seam.config</groupId>
+         <artifactId>seam-config-xml</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>javax.validation</groupId>
          <artifactId>validation-api</artifactId>
          <scope>provided</scope>

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderAuthenticationService.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderAuthenticationService.java
@@ -52,7 +52,7 @@ public class OpenIdProviderAuthenticationService {
     private Instance<DialogueBean> dialogue;
 
     @Inject
-    private Instance<OpenIdProviderBean> opBean;
+    private Instance<OpenIdProviderBeanApi> opBean;
 
     public void handleIncomingMessage(HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws InvalidRequestException {
         ParameterList parameterList = new ParameterList(httpRequest.getParameterMap());

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderBean.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderBean.java
@@ -37,7 +37,7 @@ import org.openid4java.discovery.DiscoveryInformation;
  */
 @Typed(OpenIdProviderBean.class)
 @SuppressWarnings("restriction")
-public class OpenIdProviderBean extends EntityBean implements OpenIdProviderApi, OpenIdProviderConfigurationApi {
+public class OpenIdProviderBean extends EntityBean implements OpenIdProviderBeanApi {
     @Inject
     private Instance<OpenIdProviderRequest> openIdProviderRequest;
 

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderBeanApi.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderBeanApi.java
@@ -1,0 +1,17 @@
+package org.jboss.seam.security.external.openid;
+
+import java.io.Writer;
+
+import org.jboss.seam.security.external.openid.api.OpenIdProviderApi;
+import org.jboss.seam.security.external.openid.api.OpenIdProviderConfigurationApi;
+
+/**
+ * @author Marek Schmidt (maschmid AT redhat.com)
+ */
+public interface OpenIdProviderBeanApi extends OpenIdProviderApi, OpenIdProviderConfigurationApi {
+    String getServiceURL(OpenIdService openIdService);
+    String getUsersUrlPrefix();
+    void writeClaimedIdentifierXrds(Writer writer, String opLocalIdentifier);
+    String getUserNameFromOpLocalIdentifier(String opLocalIdentifier);
+    void writeOpIdentifierXrds(Writer writer);
+}

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderInApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderInApplicationScopeProducer.java
@@ -1,14 +1,15 @@
 package org.jboss.seam.security.external.openid;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
+
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class OpenIdProviderInApplicationScopeProducer {
     @Produces
     @ApplicationScoped

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderInVirtualApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdProviderInVirtualApplicationScopeProducer.java
@@ -1,15 +1,15 @@
 package org.jboss.seam.security.external.openid;
 
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
 
 import org.jboss.seam.security.external.virtualapplications.api.VirtualApplicationScoped;
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class OpenIdProviderInVirtualApplicationScopeProducer {
     @Produces
     @VirtualApplicationScoped

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpAuthenticationService.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpAuthenticationService.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -50,7 +49,7 @@ class OpenIdRpAuthenticationService {
     private Instance<OpenIdRelyingPartySpi> openIdRelyingPartySpi;
 
     @Inject
-    private OpenIdRpBean relyingPartyBean;
+    private Instance<OpenIdRpBeanApi> relyingPartyBean;
 
     @Inject
     private ResponseHandler responseHandler;
@@ -77,7 +76,7 @@ class OpenIdRpAuthenticationService {
             }
 
             // extract the receiving URL from the HTTP request            
-            StringBuffer receivingURL = new StringBuffer(relyingPartyBean.getServiceURL(OpenIdService.OPEN_ID_SERVICE));
+            StringBuffer receivingURL = new StringBuffer(relyingPartyBean.get().getServiceURL(OpenIdService.OPEN_ID_SERVICE));
             
             if (queryString != null && queryString.length() > 0)
                 receivingURL.append("?").append(queryString);
@@ -129,8 +128,8 @@ class OpenIdRpAuthenticationService {
 
             openIdRequest.setDiscoveryInformation(discovered);
 
-            String realm = relyingPartyBean.getRealm();
-            String returnTo = relyingPartyBean.getServiceURL(
+            String realm = relyingPartyBean.get().getRealm();
+            String returnTo = relyingPartyBean.get().getServiceURL(
                     OpenIdService.OPEN_ID_SERVICE) + "?dialogueId=" + dialogue.get().getId();
             AuthRequest authReq = openIdConsumerManager.authenticate(discovered, returnTo, realm);
 

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpBean.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpBean.java
@@ -3,7 +3,7 @@ package org.jboss.seam.security.external.openid;
 import java.io.Writer;
 import java.util.List;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
@@ -21,18 +21,15 @@ import org.jboss.seam.security.external.jaxb.xrds.Type;
 import org.jboss.seam.security.external.jaxb.xrds.URIPriorityAppendPattern;
 import org.jboss.seam.security.external.jaxb.xrds.XRD;
 import org.jboss.seam.security.external.jaxb.xrds.XRDS;
-import org.jboss.seam.security.external.openid.api.OpenIdRelyingPartyApi;
-import org.jboss.seam.security.external.openid.api.OpenIdRelyingPartyConfigurationApi;
 import org.jboss.seam.security.external.openid.api.OpenIdRequestedAttribute;
 import org.openid4java.discovery.DiscoveryInformation;
 
 /**
  * @author Marcel Kolsteren
  */
-//@Typed(OpenIdRpBean.class)
-@ApplicationScoped
+@Typed(OpenIdRpBean.class)
 @SuppressWarnings("restriction")
-public class OpenIdRpBean extends EntityBean implements OpenIdRelyingPartyApi, OpenIdRelyingPartyConfigurationApi {
+public class OpenIdRpBean extends EntityBean implements OpenIdRpBeanApi {
     @Inject
     private OpenIdRpAuthenticationService openIdSingleLoginSender;
 

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpBeanApi.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpBeanApi.java
@@ -1,0 +1,14 @@
+package org.jboss.seam.security.external.openid;
+
+import java.io.Writer;
+
+import org.jboss.seam.security.external.openid.api.OpenIdRelyingPartyApi;
+import org.jboss.seam.security.external.openid.api.OpenIdRelyingPartyConfigurationApi;
+
+/**
+ * @author Marek Schmidt (maschmid AT redhat.com)
+ */
+public interface OpenIdRpBeanApi extends OpenIdRelyingPartyApi, OpenIdRelyingPartyConfigurationApi {
+    String getServiceURL(OpenIdService service);
+    void writeRpXrds(Writer writer);
+}

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpInApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpInApplicationScopeProducer.java
@@ -1,14 +1,20 @@
 package org.jboss.seam.security.external.openid;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.New;
+import javax.enterprise.inject.Produces;
+
+import org.jboss.seam.solder.core.Veto;
+
 /**
  * @author Marcel Kolsteren
  */
-//@Alternative
+@Veto
 public class OpenIdRpInApplicationScopeProducer {
-    /*@Produces
+    @Produces
     @ApplicationScoped
     public OpenIdRpBean produce(@New OpenIdRpBean rp)
     {
        return rp;
-    }*/
+    }
 }

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpInVirtualApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdRpInVirtualApplicationScopeProducer.java
@@ -1,15 +1,15 @@
 package org.jboss.seam.security.external.openid;
 
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
 
 import org.jboss.seam.security.external.virtualapplications.api.VirtualApplicationScoped;
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class OpenIdRpInVirtualApplicationScopeProducer {
     @Produces
     @VirtualApplicationScoped

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdServerManagerFactory.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdServerManagerFactory.java
@@ -1,6 +1,7 @@
 package org.jboss.seam.security.external.openid;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
@@ -14,7 +15,7 @@ public class OpenIdServerManagerFactory {
     private ServerManager serverManager;
 
     @Inject
-    private OpenIdProviderBean providerBean;
+    private Instance<OpenIdProviderBeanApi> providerBean;
 
     @Produces
     public ServerManager getServerManager() {
@@ -24,6 +25,6 @@ public class OpenIdServerManagerFactory {
     @Inject
     public void startup() throws Exception {
         serverManager = new ServerManager();
-        serverManager.setOPEndpointUrl(providerBean.getServiceURL(OpenIdService.OPEN_ID_SERVICE));
+        serverManager.setOPEndpointUrl(providerBean.get().getServiceURL(OpenIdService.OPEN_ID_SERVICE));
     }
 }

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdServlet.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdServlet.java
@@ -35,10 +35,10 @@ public class OpenIdServlet extends HttpServlet {
     private OpenIdRpAuthenticationService openIdRpAuthenticationService;
 
     @Inject
-    private Instance<OpenIdRpBean> rpBean;
+    private Instance<OpenIdRpBeanApi> rpBean;
 
     @Inject
-    private Instance<OpenIdProviderBean> opBean;
+    private Instance<OpenIdProviderBeanApi> opBean;
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {

--- a/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdUsersServlet.java
+++ b/external/src/main/java/org/jboss/seam/security/external/openid/OpenIdUsersServlet.java
@@ -19,7 +19,7 @@ public class OpenIdUsersServlet extends HttpServlet {
     private static final long serialVersionUID = 1476698956314628568L;
 
     @Inject
-    private Instance<OpenIdProviderBean> opBean;
+    private Instance<OpenIdProviderBeanApi> opBean;
 
     @Inject
     private Instance<OpenIdProviderSpi> providerSpi;

--- a/external/src/main/java/org/jboss/seam/security/external/saml/SamlMessageReceiver.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/SamlMessageReceiver.java
@@ -28,9 +28,10 @@ import org.jboss.seam.security.external.jaxb.samlv2.protocol.RequestAbstractType
 import org.jboss.seam.security.external.jaxb.samlv2.protocol.ResponseType;
 import org.jboss.seam.security.external.jaxb.samlv2.protocol.StatusResponseType;
 import org.jboss.seam.security.external.saml.idp.SamlIdpBean;
+import org.jboss.seam.security.external.saml.idp.SamlIdpBeanApi;
 import org.jboss.seam.security.external.saml.idp.SamlIdpSingleLogoutService;
 import org.jboss.seam.security.external.saml.idp.SamlIdpSingleSignOnService;
-import org.jboss.seam.security.external.saml.sp.SamlSpBean;
+import org.jboss.seam.security.external.saml.sp.SamlSpBeanApi;
 import org.jboss.seam.security.external.saml.sp.SamlSpSingleLogoutService;
 import org.jboss.seam.security.external.saml.sp.SamlSpSingleSignOnService;
 import org.w3c.dom.Document;
@@ -67,10 +68,10 @@ public class SamlMessageReceiver {
     private Instance<SamlEntityBean> samlEntityBean;
 
     @Inject
-    private Instance<SamlSpBean> samlSpBean;
+    private Instance<SamlSpBeanApi> samlSpBean;
 
     @Inject
-    private Instance<SamlIdpBean> samlIdpBean;
+    private Instance<SamlIdpBeanApi> samlIdpBean;
 
     @Inject
     private SamlSignatureUtilForPostBinding signatureUtilForPostBinding;

--- a/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpBean.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpBean.java
@@ -41,7 +41,7 @@ import org.jboss.seam.security.external.saml.api.SamlPrincipal;
  */
 @Typed(SamlIdpBean.class)
 @SuppressWarnings("restriction")
-public class SamlIdpBean extends SamlEntityBean implements SamlMultiUserIdentityProviderApi, SamlIdentityProviderConfigurationApi {
+public class SamlIdpBean extends SamlEntityBean implements SamlIdpBeanApi {
     @Inject
     private SamlIdpSingleSignOnService samlIdpSingleSignOnService;
 

--- a/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpBeanApi.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpBeanApi.java
@@ -1,0 +1,11 @@
+package org.jboss.seam.security.external.saml.idp;
+
+import org.jboss.seam.security.external.SamlMultiUserIdentityProviderApi;
+import org.jboss.seam.security.external.saml.api.SamlIdentityProviderConfigurationApi;
+
+/**
+ * @author Marek Schmidt (maschmid AT redhat.com)
+ */
+public interface SamlIdpBeanApi extends SamlMultiUserIdentityProviderApi, SamlIdentityProviderConfigurationApi {
+
+}

--- a/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpInApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpInApplicationScopeProducer.java
@@ -1,14 +1,15 @@
 package org.jboss.seam.security.external.saml.idp;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
+
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class SamlIdpInApplicationScopeProducer {
     @Produces
     @ApplicationScoped

--- a/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpInVirtualApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/idp/SamlIdpInVirtualApplicationScopeProducer.java
@@ -1,16 +1,16 @@
 package org.jboss.seam.security.external.saml.idp;
 
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
 
 import org.jboss.seam.security.external.virtualapplications.api.VirtualApplication;
 import org.jboss.seam.security.external.virtualapplications.api.VirtualApplicationScoped;
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class SamlIdpInVirtualApplicationScopeProducer {
     @Produces
     @VirtualApplicationScoped

--- a/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpBean.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpBean.java
@@ -33,7 +33,7 @@ import org.jboss.seam.security.external.saml.api.SamlSpSession;
  */
 @Typed(SamlSpBean.class)
 @SuppressWarnings("restriction")
-public class SamlSpBean extends SamlEntityBean implements SamlMultiUserServiceProviderApi, SamlServiceProviderConfigurationApi {
+public class SamlSpBean extends SamlEntityBean implements SamlSpBeanApi, SamlMultiUserServiceProviderApi, SamlServiceProviderConfigurationApi {
     private List<SamlExternalIdentityProvider> identityProviders = new LinkedList<SamlExternalIdentityProvider>();
 
     @Inject

--- a/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpBeanApi.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpBeanApi.java
@@ -1,0 +1,8 @@
+package org.jboss.seam.security.external.saml.sp;
+
+import org.jboss.seam.security.external.SamlMultiUserServiceProviderApi;
+import org.jboss.seam.security.external.saml.api.SamlServiceProviderConfigurationApi;
+
+public interface SamlSpBeanApi extends SamlMultiUserServiceProviderApi, SamlServiceProviderConfigurationApi {
+
+}

--- a/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpInApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpInApplicationScopeProducer.java
@@ -1,14 +1,15 @@
 package org.jboss.seam.security.external.saml.sp;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
+
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class SamlSpInApplicationScopeProducer {
     @Produces
     @ApplicationScoped

--- a/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpInVirtualApplicationScopeProducer.java
+++ b/external/src/main/java/org/jboss/seam/security/external/saml/sp/SamlSpInVirtualApplicationScopeProducer.java
@@ -1,16 +1,16 @@
 package org.jboss.seam.security.external.saml.sp;
 
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.New;
 import javax.enterprise.inject.Produces;
 
 import org.jboss.seam.security.external.virtualapplications.api.VirtualApplication;
 import org.jboss.seam.security.external.virtualapplications.api.VirtualApplicationScoped;
+import org.jboss.seam.solder.core.Veto;
 
 /**
  * @author Marcel Kolsteren
  */
-@Alternative
+@Veto
 public class SamlSpInVirtualApplicationScopeProducer {
     @Produces
     @VirtualApplicationScoped

--- a/external/src/test/java/org/jboss/seam/security/externaltest/integration/client/ArchiveBuilder.java
+++ b/external/src/test/java/org/jboss/seam/security/externaltest/integration/client/ArchiveBuilder.java
@@ -44,6 +44,7 @@ class ArchiveBuilder {
         		.artifact("org.jboss.seam.security:seam-security")
         		.artifact("org.jboss.seam.servlet:seam-servlet")
         		.artifact("org.jboss.seam.solder:seam-solder")
+        		.artifact("org.jboss.seam.config:seam-config-xml")
         		.artifact("org.openid4java:openid4java-consumer:pom").exclusion("xerces:xercesImpl")
         		.artifact("nekohtml:nekohtml")
         		.artifact("org.apache:xmlsec")
@@ -51,6 +52,7 @@ class ArchiveBuilder {
         		.resolveAs(GenericArchive.class));
 
         war.addAsWebInfResource("WEB-INF/" + entity + "-beans.xml", "beans.xml");
+        war.addAsWebInfResource("WEB-INF/" + entity + "-seam-beans.xml", "classes/META-INF/seam-beans.xml");
         war.addAsWebInfResource("WEB-INF/context.xml", "context.xml");
 
         war.addPackage(MetaDataLoader.class.getPackage());

--- a/external/src/test/resources/WEB-INF/idp-beans.xml
+++ b/external/src/test/resources/WEB-INF/idp-beans.xml
@@ -1,6 +1,8 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    <!-- 
     <alternatives>
         <class>org.jboss.seam.security.external.saml.idp.SamlIdpInApplicationScopeProducer</class>
     </alternatives>
+    -->
 </beans>

--- a/external/src/test/resources/WEB-INF/idp-seam-beans.xml
+++ b/external/src/test/resources/WEB-INF/idp-seam-beans.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"
+       xmlns:s="urn:java:ee"
+       xmlns:idp="urn:java:org.jboss.seam.security.external.saml.idp">
+  
+    <idp:SamlIdpInApplicationScopeProducer>
+        <s:modifies/>
+    </idp:SamlIdpInApplicationScopeProducer>
+</beans>

--- a/external/src/test/resources/WEB-INF/op-beans.xml
+++ b/external/src/test/resources/WEB-INF/op-beans.xml
@@ -1,6 +1,8 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    <!--
     <alternatives>
         <class>org.jboss.seam.security.external.openid.OpenIdProviderInApplicationScopeProducer</class>
     </alternatives>
+      -->
 </beans>

--- a/external/src/test/resources/WEB-INF/op-seam-beans.xml
+++ b/external/src/test/resources/WEB-INF/op-seam-beans.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"
+       xmlns:s="urn:java:ee"
+       xmlns:op="urn:java:org.jboss.seam.security.external.openid">
+       
+    <op:OpenIdProviderInApplicationScopeProducer>
+        <s:modifies/>
+    </op:OpenIdProviderInApplicationScopeProducer>
+</beans>

--- a/external/src/test/resources/WEB-INF/rp-seam-beans.xml
+++ b/external/src/test/resources/WEB-INF/rp-seam-beans.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"
+       xmlns:s="urn:java:ee"
+       xmlns:rp="urn:java:org.jboss.seam.security.external.openid">
+
+    <rp:OpenIdRpInApplicationScopeProducer>
+        <s:modifies/>
+    </rp:OpenIdRpInApplicationScopeProducer>
+</beans>

--- a/external/src/test/resources/WEB-INF/sp-beans.xml
+++ b/external/src/test/resources/WEB-INF/sp-beans.xml
@@ -1,6 +1,8 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+    <!-- 
     <alternatives>
         <class>org.jboss.seam.security.external.saml.sp.SamlSpInVirtualApplicationScopeProducer</class>
     </alternatives>
+    -->
 </beans>

--- a/external/src/test/resources/WEB-INF/sp-seam-beans.xml
+++ b/external/src/test/resources/WEB-INF/sp-seam-beans.xml
@@ -1,0 +1,11 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"
+       xmlns:s="urn:java:ee"
+       xmlns:sp="urn:java:org.jboss.seam.security.external.saml.sp"
+       xmlns:virt="urn:java:org.jboss.seam.security.external.virtualapplications.api">
+       
+    <sp:SamlSpInVirtualApplicationScopeProducer>
+        <s:modifies/>
+    </sp:SamlSpInVirtualApplicationScopeProducer>
+</beans>
+


### PR DESCRIPTION
Two commits:

The first one changes the configuration of *ScopeProducers from CDI alternatives (which don't work across Bean Archives unless on non-standard-complaint JBoss AS 6 ) to Seam Config. This change is necessary for AS7.

All the *ScopeProducers (such as OpenIdProviderInVirtualApplicationScopeProducer,  OpenIdProviderInApplicationScopeProducer, ...) are @Vetoed, and to enable the specific producer, you now have to use, e.g.:

&lt;idp:SamlIdpInApplicationScopeProducer>
     &lt;s:modifies/>
&lt;/idp:SamlIdpInApplicationScopeProducer>

in seam-beans.xml

The other changes in this commit are necessary to avoid Unresolved and Ambiguous dependencies, this introduces new interfaces (OpenIdRpBeanApi, OpenIdProviderBeanApi, ...) that are used internally to inject the "entity beans" (OpenIdRpBean, OpenIdProviderBean, ...)  it is important to always use these when injecting the beans so we ensure that the correct configured producer is used... (I assume this was the original design) 

The other commit fixes the examples wrt. these changes and makes them work on AS7.
