### PR TITLE
Feature/seamsecurity 98

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -102,7 +102,7 @@
          <useProjectArtifact>false</useProjectArtifact>
          <includes>
             <include>org.jboss.seam.security:seam-security-api:*:sources</include>
-            <include>org.jboss.seam.security:seam-security-impl:*:sources</include>
+            <include>org.jboss.seam.security:seam-security:*:sources</include>
             <include>org.jboss.seam.security:seam-security-external:*:sources</include>
          </includes>
          <unpackOptions>

--- a/impl/src/main/java/org/jboss/seam/security/jaas/JaasAuthenticator.java
+++ b/impl/src/main/java/org/jboss/seam/security/jaas/JaasAuthenticator.java
@@ -59,7 +59,7 @@ class JaasAuthenticator extends BaseAuthenticator implements Authenticator {
         try {
             getLoginContext().login();
             setStatus(AuthenticationStatus.SUCCESS);
-            setUser(new SimpleUser(credentials.getUsername()));
+            setUser(new SimpleUser(credentials.getUsername())); //SEAMSECURITY-98
         } catch (LoginException e) {
             setStatus(AuthenticationStatus.FAILURE);
             log.error("JAAS authentication failed", e);

--- a/impl/src/main/java/org/jboss/seam/security/jaas/JaasAuthenticator.java
+++ b/impl/src/main/java/org/jboss/seam/security/jaas/JaasAuthenticator.java
@@ -21,6 +21,7 @@ import org.jboss.seam.security.BaseAuthenticator;
 import org.jboss.seam.security.Credentials;
 import org.jboss.seam.security.Identity;
 import org.picketlink.idm.impl.api.PasswordCredential;
+import org.picketlink.idm.impl.api.model.SimpleUser;
 
 /**
  * An authenticator for authenticating with JAAS.  The jaasConfigName property
@@ -58,6 +59,7 @@ class JaasAuthenticator extends BaseAuthenticator implements Authenticator {
         try {
             getLoginContext().login();
             setStatus(AuthenticationStatus.SUCCESS);
+            setUser(new SimpleUser(credentials.getUsername()));
         } catch (LoginException e) {
             setStatus(AuthenticationStatus.FAILURE);
             log.error("JAAS authentication failed", e);


### PR DESCRIPTION
The Jaas security implementation was missing the setUser method after a successful login, resulting in an error even if the correct login information was used
