### PR TITLE
SEAMSECURITY-122 enable transaction interceptor in the idmconsole example

### DIFF
--- a/examples/idmconsole/src/main/resources-jbossas6/WEB-INF/beans.xml
+++ b/examples/idmconsole/src/main/resources-jbossas6/WEB-INF/beans.xml
@@ -9,14 +9,8 @@
       http://java.sun.com/xml/ns/javaee
       http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
       
-    <!-- Workaround for a JBoss AS 6 bug JBAS-8849, the interceptor is already declared in 
-         seam-security-impl.jar and AS6 incorrectly treats it as declared in all 
-         bean archives in the application -->
-
-<!--    
     <interceptors>
         <class>org.jboss.seam.transaction.TransactionInterceptor</class>
     </interceptors>
--->
 
 </beans>


### PR DESCRIPTION
SEAMSECURITY-122 enable transaction interceptor in the idmconsole example AS6 profile

Since the seam-security-impl.jar doesn't declare the transaction interceptor anymore, the workaround for JBAS-8849 is not valid.
