### PR TITLE
make the jbossas-managed-7 testsuite profile working on 7.1

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -75,13 +75,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.0.0.GA</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
         </dependency>

--- a/testsuite/src/test/resources/jndi.properties
+++ b/testsuite/src/test/resources/jndi.properties
@@ -1,3 +1,0 @@
-java.naming.factory.initial=org.jnp.interfaces.NamingContextFactory
-java.naming.factory.url.pkgs=org.jboss.naming\:org.jnp.interfaces 
-java.naming.provider.url=jnp://localhost:1099


### PR DESCRIPTION
(run with 

mvn clean verify -Darquillian=jbossas-managed-7 -Djbossas7.version=7.1.0.Final -Darquillian.version=1.0.0.CR7

unless also updating parent to the latest 20-SNAPSHOT)
