### PR TITLE
Prevent ClassCastException if credentials are not of type PasswordCredential

### DIFF
--- a/impl/src/main/java/org/jboss/seam/security/CredentialsImpl.java
+++ b/impl/src/main/java/org/jboss/seam/security/CredentialsImpl.java
@@ -82,9 +82,9 @@ class CredentialsImpl implements Credentials, Serializable {
         if (this.credential == null) {
             this.credential = new PasswordCredential(password);
         } else if (this.credential != null && this.credential instanceof PasswordCredential &&
-                ((PasswordCredential) this.credential).getValue() != password &&
+                (((PasswordCredential) this.credential).getValue() != password &&
                 ((PasswordCredential) this.credential).getValue() == null ||
-                !((PasswordCredential) this.credential).getValue().equals(password)) {
+                !((PasswordCredential) this.credential).getValue().equals(password))) {
             this.credential = new PasswordCredential(password);
             invalid = false;
             manager.fireEvent(new CredentialsUpdatedEvent());


### PR DESCRIPTION
In setPassword, if the current credential is not of type password then the final OR clause will still be executed causing a ClassCastException.
